### PR TITLE
style: rollback type-only imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -9,6 +9,13 @@
       "indentStyle": "space"
     }
   },
+  "linter": {
+    "rules": {
+      "style": {
+        "useImportType": "off"
+      }
+    }
+  },
   "json": {
     "formatter": {
       "indentStyle": "space"

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import type { AppService } from './app.service';
+import { AppService } from './app.service';
 
 @Controller()
 export class AppController {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,8 +1,8 @@
 import { CacheModule } from '@nestjs/cache-manager';
 import {
-  type MiddlewareConsumer,
+  MiddlewareConsumer,
   Module,
-  type NestModule,
+  NestModule,
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';

--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -1,11 +1,11 @@
 import {
-  type CanActivate,
-  type ExecutionContext,
+  CanActivate,
+  ExecutionContext,
   Injectable,
 } from '@nestjs/common';
-import type { Reflector } from '@nestjs/core';
-import type { Request } from 'express';
-import type { PrismaService } from 'src/prisma/prisma.service';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { RequireAuthToken } from '../decorators/required-auth-token.decorator';
 
 @Injectable()

--- a/src/http-response.middleware.ts
+++ b/src/http-response.middleware.ts
@@ -1,7 +1,7 @@
-import { Injectable, type NestMiddleware } from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
-import type { Request, Response } from 'express';
-import type { Counter } from 'prom-client';
+import { Request, Response } from 'express';
+import { Counter } from 'prom-client';
 
 @Injectable()
 export class HttpResponseMiddleware implements NestMiddleware {

--- a/src/job/job.controller.ts
+++ b/src/job/job.controller.ts
@@ -1,10 +1,10 @@
 import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { RequireAuthToken } from 'src/common/decorators/required-auth-token.decorator';
 import { AuthGuard } from 'src/common/guards/auth.guard';
-import type { CreateClaimItemsEventDto } from './dto/create-claim-items-event.dto';
-import type { CreateClaimItemsDto } from './dto/create-claim-items.dto';
-import type { CreateTransferAssetsDto } from './dto/create-transfer-assets.dto';
-import type { JobService } from './job.service';
+import { CreateClaimItemsEventDto } from './dto/create-claim-items-event.dto';
+import { CreateClaimItemsDto } from './dto/create-claim-items.dto';
+import { CreateTransferAssetsDto } from './dto/create-transfer-assets.dto';
+import { JobService } from './job.service';
 
 @UseGuards(AuthGuard)
 @Controller('jobs')

--- a/src/job/job.service.ts
+++ b/src/job/job.service.ts
@@ -6,12 +6,12 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import type { Job, TxResult } from '@prisma/client';
-import type { PrismaService } from 'src/prisma/prisma.service';
-import type { TxService } from 'src/tx/tx.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { TxService } from 'src/tx/tx.service';
 import { getCurrency } from 'src/utils/currency';
-import type { CreateClaimItemsEventDto } from './dto/create-claim-items-event.dto';
-import type { CreateClaimItemsDto } from './dto/create-claim-items.dto';
-import type { CreateTransferAssetsDto } from './dto/create-transfer-assets.dto';
+import { CreateClaimItemsEventDto } from './dto/create-claim-items-event.dto';
+import { CreateClaimItemsDto } from './dto/create-claim-items.dto';
+import { CreateTransferAssetsDto } from './dto/create-transfer-assets.dto';
 import { JobStatus, getJobStatusFromTxResult } from './job-status.entity';
 
 @Injectable()

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, type OnModuleInit } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()

--- a/src/queue/queue.cron.ts
+++ b/src/queue/queue.cron.ts
@@ -2,9 +2,9 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
-import type { Cache } from 'cache-manager';
-import type { Gauge } from 'prom-client';
-import type { QueueService } from './queue.service';
+import { Cache } from 'cache-manager';
+import { Gauge } from 'prom-client';
+import { QueueService } from './queue.service';
 
 const handleCronLock = 'HANDLE_CRON_LOCK';
 const handleStagingCronLock = 'HANDLE_STAGING_CRON_LOCK';

--- a/src/queue/queue.service.ts
+++ b/src/queue/queue.service.ts
@@ -1,9 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import { ActionType, type Job, Prisma } from '@prisma/client';
 
-import type { PrismaService } from 'src/prisma/prisma.service';
-import type { TxService } from 'src/tx/tx.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { TxService } from 'src/tx/tx.service';
 
 const DEFAULT_TX_ACTIONS_SIZE = 100;
 const JOT_RETRY_LIMIT = 1;

--- a/src/transaction/transaction.controller.ts
+++ b/src/transaction/transaction.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Param } from '@nestjs/common';
-import type { TransactionService } from './transaction.service';
+import { TransactionService } from './transaction.service';
 
 @Controller('transactions')
 export class TransactionController {

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -5,8 +5,8 @@ import {
 } from '@nestjs/common';
 import { TxResult } from '@prisma/client';
 import { getJobStatusFromTxResult } from 'src/job/job-status.entity';
-import type { PrismaService } from 'src/prisma/prisma.service';
-import type { TxService } from 'src/tx/tx.service';
+import  { PrismaService } from 'src/prisma/prisma.service';
+import  { TxService } from 'src/tx/tx.service';
 
 const UPDATE_TRANSACTIONS_SIZE = 10;
 

--- a/src/tx/tx.service.ts
+++ b/src/tx/tx.service.ts
@@ -1,16 +1,16 @@
 import { createHash } from 'node:crypto';
 import { Injectable } from '@nestjs/common';
-import type { ConfigService } from '@nestjs/config';
+import { ConfigService } from '@nestjs/config';
 import type { Account } from '@planetarium/account';
 import { BencodexDictionary, type Value, encode } from '@planetarium/bencodex';
 import type { UnsignedTx } from '@planetarium/tx/dist/tx';
 import type { Job, TxResult } from '@prisma/client';
 
-import type { HttpService } from '@nestjs/axios';
+import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
-import type { ActionService } from './action.service';
+import { ActionService } from './action.service';
 import { CURRENCIES, SUPER_FUTURE_DATETIME } from './tx.constants';
-import type { Tx } from './tx.entity';
+import { Tx } from './tx.entity';
 
 import { Address, PublicKey } from '@planetarium/account';
 import { AwsKmsAccount, KMSClient } from '@planetarium/account-aws-kms';

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,4 +1,4 @@
-import { type ValidationOptions, registerDecorator } from 'class-validator';
+import { ValidationOptions, registerDecorator } from 'class-validator';
 
 type Currency = {
   type: 'constant' | 'prefix' | 'string_prefix';

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
 import type { INestApplication } from '@nestjs/common';
-import { Test, type TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
 import { AppModule } from './../src/app.module';
 


### PR DESCRIPTION
In #71, it applied `biome` lint rules and their fixes. But NestJS uses type informations with reflector so those types should be included.